### PR TITLE
WINSRV not WINSVR

### DIFF
--- a/ts/services/ReportService.ts
+++ b/ts/services/ReportService.ts
@@ -82,7 +82,7 @@ class ReportService {
   private async getElementsInScope(config, logger, report: Report): Promise<ReportContent> {
 
     const reportScope = new ReportViewScope('elementsInScope', {
-      elementTypes: ['EC2', 'WINSVR', 'SERVER'],
+      elementTypes: ['EC2', 'WINSRV', 'SERVER'],
       endDate: this.getEndDate(report.endDate, config.period),
       startDate: this.getStartDate(report.endDate, config.period)
     },


### PR DESCRIPTION
Result is WINSRV elements not showing in the output of a `metricly report ec2cost` command.